### PR TITLE
added XSLT to Python autotagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Thumbs.db
 .idea/
 venv/
 __pycache__/
+*.xpr

--- a/posTag-Cleanup.xsl
+++ b/posTag-Cleanup.xsl
@@ -13,7 +13,7 @@
         
      <xsl:for-each select="$verbTagged">
          <xsl:variable name="filename" as="xs:string" select="current() ! base-uri() ! tokenize(., '/')[last()]"/>
-         <xsl:result-document method="xml" indent="yes" href="verbTaggedClean-xml/{$filename}">
+         <xsl:result-document method="xml" indent="yes" href="{$filename}">
              
             <xsl:apply-templates/>
              

--- a/python/NLP-VerbTagger.py
+++ b/python/NLP-VerbTagger.py
@@ -22,6 +22,7 @@ nlp = spacy.load('en_core_web_lg')
 ##################################################################################
 CollPath = '../xml'
 TargetPath = '../verbTagged-xml'
+cleanUpPath = '../verbTaggedClean-xml'
 
 #########################################################################################
 # ebb: After reading the sorted dictionary output, we know spaCy is making some mistakes.
@@ -182,6 +183,21 @@ def xmlTagger(sourcePath, SortedDict):
         # ebb: Output goes in the taggedOutput directory: ../taggedOutput
         with open(targetFile, 'w') as f:
             f.write(cleanedUp)
+        cleanup = xsltCleaner(targetFile)
+        return (cleanup)
+def xsltCleaner(targetFile):
+    print("xsltCleaner: ", f"{targetFile=}")
+    # for file in os.listdir(TargetPath):
+    #     if file.endswith(".xml"):
+    # filepath = f"{TargetPath}/{targetFile}"
+    toCleanFilename = os.path.basename(targetFile)
+    print(f"{toCleanFilename=}")
+    with PySaxonProcessor(license=False) as proc:
+        xsltproc = proc.new_xslt30_processor()
+        # xsltCompile = xsltproc.compile_stylesheet(stylesheet_file="posTag-Cleanup.xsl.xsl", save=True, output_file=f"{XSLTPath}/{toCleanFilename}")
+        output = xsltproc.transform_to_file(source_file=targetFile, stylesheet_file="../posTag-Cleanup.xsl", output_file=f"{cleanUpPath}/{toCleanFilename}")
+    return output
+
 
 assembleAllVerbs(CollPath)
 

--- a/verbTaggedClean-xml/AOTC.xml
+++ b/verbTaggedClean-xml/AOTC.xml
@@ -213,7 +213,7 @@ applause.</sd>
 			I don't <verb lemma="know">know</verb> how much longer I can
 			<verb lemma="hold">hold</verb> off the vote, my friends.
 			More and more star systems <verb lemma="be">are</verb>
-			<verb lemma="join">joining</verb> the separatists.</sp>
+			joining the separatists.</sp>
       <sp>
          <speaker>MACE WINDU</speaker>
 			If they <verb lemma="do">do</verb>
@@ -1796,7 +1796,7 @@ vastness of the spaceport with ARTOO trundling along behind them.</sd>
 			history I studied, the more I
 			realised how much good politicians
 			could do. So when I <verb lemma="be">was</verb> eight, I
-			<verb lemma="join">joined</verb> the "Apprentice
+			joined the "Apprentice
 			Legislators", then later on became
 			a Senatorial advisor, with such a
 			passion that, before I <verb lemma="know">knew</verb> it, I
@@ -1866,7 +1866,7 @@ vastness of the spaceport with ARTOO trundling along behind them.</sd>
 			Her Highness could <verb lemma="have">have</verb> made.</sp>
       <sp>
          <speaker>QUEEN JAMILLIA</speaker>
-			How many systems <verb lemma="have">have</verb> <verb lemma="join">joined</verb> <verb lemma="count">Count</verb>
+			How many systems <verb lemma="have">have</verb> joined <verb lemma="count">Count</verb>
 			Dooku and the separatists?</sp>
       <sp>
          <speaker>PADME</speaker>

--- a/verbTaggedClean-xml/esb.xml
+++ b/verbTaggedClean-xml/esb.xml
@@ -445,7 +445,7 @@ stiffly over to him.</sd>
          <speaker>THREEPIO</speaker>
 		You must <verb lemma="come">come</verb> along now, Artoo.  
 		There's really nothing more we can 
-		do.  And my <verb lemma="join">joints</verb> <verb lemma="be">are</verb> freezing up.</sp>
+		do.  And my joints <verb lemma="be">are</verb> freezing up.</sp>
       <sd>Artoo beeps, long and low.</sd>
       <sp>
          <speaker>THREEPIO</speaker>


### PR DESCRIPTION
Here is a Pull Request with an updated version of the Python autotagger that we worked on in the meeting last week. This version runs an XSLT file at the end of the process to remove the nested `<verb>` tags that get set inside other `<verb>` tags. Basically when you add a new or updated XML file to be processed / autotagged (like ANH that @JaxAbele is preparing), you can just run this updated Python and it should take care of autotagging and clean-up in one file.

NOTE: It takes several minutes to run: be patient and wait for the whole program to finish with the exit code at the end. Star Wars verb tagging = lots of verbs! 